### PR TITLE
Change gatsby node generation to publish date

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -7,8 +7,11 @@ exports.onCreateNode = ({ node, actions }) => {
     createNodeField({
       node,
       name: `slug`,
-      value: `${dayjs(node.createdAt).format("YYYY-MM-DD")} ${node.movieTitle}`
+      value: `${dayjs(node.publishDate).format("YYYY-MM-DD")} ${
+        node.movieTitle
+      }`
         .toLowerCase()
+        .replace(/[^a-z0-9 ]/g, "")
         .split(" ")
         .join("-"),
     })

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -7,11 +7,10 @@ exports.onCreateNode = ({ node, actions }) => {
     createNodeField({
       node,
       name: `slug`,
-      value: `${dayjs(node.publishDate).format("YYYY-MM-DD")} ${
-        node.movieTitle
-      }`
+      value: `${dayjs(node.publishDate).format(
+        "YYYY-MM-DD"
+      )} ${node.movieTitle.replace(/[^a-zA-Z0-9 ]/g, "")}`
         .toLowerCase()
-        .replace(/[^a-z0-9 ]/g, "")
         .split(" ")
         .join("-"),
     })
@@ -36,7 +35,7 @@ exports.createPages = async ({ graphql, actions }) => {
           id
           grade
           movieTitle
-          createdAt
+          publishDate
           notableGrossness {
             childMarkdownRemark {
               html

--- a/src/components/FeaturedReviewSummary.js
+++ b/src/components/FeaturedReviewSummary.js
@@ -5,7 +5,7 @@ import { Link } from "gatsby"
 export default function FeaturedReviewSummary({ review }) {
   var advancedFormat = require("dayjs/plugin/advancedFormat")
   dayjs.extend(advancedFormat)
-  review.createdAt = dayjs(review.createdAt).format("MMMM Do, YYYY")
+  review.publishDate = dayjs(review.publishDate).format("MMMM Do, YYYY")
   return (
     <div className="md:w-136 md:mx-auto">
       <Link to={`/${review.fields.slug}`}>
@@ -39,7 +39,7 @@ export default function FeaturedReviewSummary({ review }) {
         }}
       ></div>
       <div className="pt-2 text-sm italic text-right text-themeDarkGray xl:text-base">
-        {review.createdAt}
+        {review.publishDate}
       </div>
     </div>
   )

--- a/src/components/RecentReviewSummary.js
+++ b/src/components/RecentReviewSummary.js
@@ -25,7 +25,7 @@ export default function RecentReviewSummary({ review, idx }) {
           }}
         ></div>
         <div className="pt-4 text-sm italic text-right text-themeDarkGray">
-          {dayjs(review.createdAt).format("MMMM Do, YYYY")}
+          {dayjs(review.publishDate).format("MMMM Do, YYYY")}
         </div>
       </Link>
     </div>

--- a/src/components/RecentReviews.js
+++ b/src/components/RecentReviews.js
@@ -10,7 +10,7 @@ export default function RecentReviews({ reviews }) {
           return (
             <RecentReviewSummary
               idx={idx}
-              key={review.movieTitle + review.createdAt}
+              key={review.movieTitle + review.publishDate}
               review={review}
             />
           )

--- a/src/components/RelatedReviews.js
+++ b/src/components/RelatedReviews.js
@@ -7,7 +7,7 @@ export default function RelatedReviews({ reviews }) {
       {reviews.map(review => {
         return (
           <RelatedReviewSummary
-            key={review.movieTitle + review.createdAt}
+            key={review.movieTitle + review.publishDate}
             review={review}
           />
         )

--- a/src/templates/Home.js
+++ b/src/templates/Home.js
@@ -40,11 +40,11 @@ export default function Home({ data }) {
 
 export const query = graphql`
   {
-    featuredReview: allContentfulReview(sort: { createdAt: DESC }, limit: 1) {
+    featuredReview: allContentfulReview(sort: { publishDate: DESC }, limit: 1) {
       nodes {
         grade
         movieTitle
-        createdAt
+        publishDate
         posterImage {
           description
           file {
@@ -64,10 +64,10 @@ export const query = graphql`
         }
       }
     }
-    recentReviews: allContentfulReview(sort: { createdAt: DESC }, skip: 1) {
+    recentReviews: allContentfulReview(sort: { publishDate: DESC }, skip: 1) {
       nodes {
         movieTitle
-        createdAt
+        publishDate
         posterImage {
           description
           file {

--- a/src/templates/Page.js
+++ b/src/templates/Page.js
@@ -6,10 +6,8 @@ import RecentReviews from "../components/RecentReviews"
 export default function Page({ data }) {
   const page = data.thisPage
 
-  const [
-    firstParagraph,
-    ...rest
-  ] = page.pageText.childMarkdownRemark.html.split("</p>")
+  const [firstParagraph, ...rest] =
+    page.pageText.childMarkdownRemark.html.split("</p>")
   const remainingParagraphs = rest.join("")
   return (
     <Layout>
@@ -40,7 +38,7 @@ export default function Page({ data }) {
 }
 
 export const query = graphql`
-  query($slug: String!) {
+  query ($slug: String!) {
     thisPage: contentfulPage(fields: { slug: { eq: $slug } }) {
       name
       pageCalloutTitle
@@ -55,10 +53,10 @@ export const query = graphql`
         }
       }
     }
-    recentReviews: allContentfulReview(sort: { createdAt: DESC }, limit: 2) {
+    recentReviews: allContentfulReview(sort: { publishDate: DESC }, limit: 2) {
       nodes {
         movieTitle
-        createdAt
+        publishDate
         posterImage {
           description
           file {

--- a/src/templates/Review.js
+++ b/src/templates/Review.js
@@ -57,10 +57,8 @@ export default function Review({ data }) {
     }
   }
 
-  const [
-    firstParagraph,
-    ...rest
-  ] = review.reviewText.childMarkdownRemark.html.split("</p>")
+  const [firstParagraph, ...rest] =
+    review.reviewText.childMarkdownRemark.html.split("</p>")
   const remainingParagraphs = rest.join("")
 
   return (
@@ -126,7 +124,7 @@ export default function Review({ data }) {
           }}
         />
         <div className="pb-8 mb-2 text-sm italic text-right text-themeDarkGray xl:text-base">
-          {dayjs(review.createdAt).format("MMMM Do, YYYY")}
+          {dayjs(review.publishDate).format("MMMM Do, YYYY")}
         </div>
       </div>
       <RelatedReviews reviews={relatedReviews} />
@@ -136,11 +134,11 @@ export default function Review({ data }) {
 }
 
 export const query = graphql`
-  query($slug: String!, $series: String!) {
+  query ($slug: String!, $series: String!) {
     thisReview: contentfulReview(fields: { slug: { eq: $slug } }) {
       grade
       movieTitle
-      createdAt
+      publishDate
       series {
         name
       }
@@ -170,10 +168,10 @@ export const query = graphql`
         slug
       }
     }
-    allReviews: allContentfulReview(sort: { createdAt: DESC }) {
+    allReviews: allContentfulReview(sort: { publishDate: DESC }) {
       nodes {
         movieTitle
-        createdAt
+        publishDate
         posterImage {
           description
           file {

--- a/src/templates/Series.js
+++ b/src/templates/Series.js
@@ -29,11 +29,11 @@ export default function Series({ data }) {
 }
 
 export const query = graphql`
-  query($series: String!) {
-    allReviews: allContentfulReview(sort: { createdAt: DESC }) {
+  query ($series: String!) {
+    allReviews: allContentfulReview(sort: { publishDate: DESC }) {
       nodes {
         movieTitle
-        createdAt
+        publishDate
         posterImage {
           description
           file {


### PR DESCRIPTION
createdAt is unreliable in the API, so I am changing slug generation and display dates to the manually-set publishDate for each entry.  This will be a little wild if anyone bookmarked a specific review but ¯\_(ツ)_/¯  Hopefully this will solve the google indexing stuff.